### PR TITLE
768 release deployment

### DIFF
--- a/.github/workflow/release.yaml
+++ b/.github/workflow/release.yaml
@@ -1,0 +1,37 @@
+name: release-publish-helm
+run-name: Release Helm Charts
+on:
+  workflow_call:
+jobs:
+  package_and_publish_helm:
+    name: Build and publish helm chart
+    runs-on: ubuntu-22.04
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v3
+        name: Checkout Code
+      - uses: jfrog/setup-jfrog-cli@v3
+        id: setup_jf_cli
+        name: Setup jfrog CLI
+        env:
+          # JFrog platform url (for example: https://acme.jfrog.io) 
+          JF_URL: ${{ secrets.FR_HELM_REPO }}
+          # JFrog Platform access token
+          JF_ACCESS_TOKEN: ${{ secrets.FR_ARTIFACTORY_USER_ACCESS_TOKEN }}
+      - id: create_helm_packages
+        name: Create Helm Packages
+        run: |
+          # For each directory in root (multiple packages to be published)
+          for d in */ ; do
+            # Get the verison value from Chart.yaml
+            version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3.4.1 yq r $d/Chart.yaml version)
+            # Make the package with the retrieved value
+            make package_helm name=$d version=$version
+          done
+      - name: Publish Helm Package to repository
+        id: publish_helm_package_to_repo
+        run: |
+          # Foreach tgz file in the dir which would have been created above
+          for tgz in $(ls *.tgz) ; do
+            make publish_helm $tgz
+          done

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ helm_repo := forgerock-helm/secure-api-gateway-helpers
 
 package_helm:
 ifndef version
-	$(error A name must be supplied, Eg. make package_helm version=1.0.0)
+	$(error A version must be supplied, Eg. make package_helm version=1.0.0)
 endif
 ifndef name
 	$(error A name must be supplied, Eg. make package_helm name=external-secrets-gsm)
@@ -11,4 +11,10 @@ endif
 	helm package ${name} --version ${version} --app-version ${version}
 
 publish_helm:
+ifndef version
+	$(error A name must be supplied, Eg. make package_helm version=1.0.0)
+endif
+ifndef name
+	$(error A helm repo must be supplied, Eg. make package_helm helm_repo=forgerock-helm/secure-api-gateway)
+endif
 	jf rt upload  ./${name} ${helm_repo}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+helm_repo := forgerock-helm/secure-api-gateway-helpers
+
+package_helm:
+ifndef version
+	$(error A name must be supplied, Eg. make package_helm version=1.0.0)
+endif
+ifndef name
+	$(error A name must be supplied, Eg. make package_helm name=external-secrets-gsm)
+endif
+	helm dependency update ${name}
+	helm package ${name} --version ${version} --app-version ${version}
+
+publish_helm:
+	jf rt upload  ./${name} ${helm_repo}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # secure-api-gateway-releases-helpers
+
+This repo holds helm charts for packages that will aid in the running of secure-api-gateway.
+
+## Mutating Webhook
+The mutating webhooks functionality is to apply a whitelist to any ingesses within the cluster, it will also update the SSL certificates used by the ingresses if they are updated via the External Secrets package.
+
+## External Secrets GSM
+The external secrets Google Secrets Manager charts specify the secrets to be created in the kubernetes cluster. We use Google Secrets Manager for our secrets, but other secrets managers can be used. 

--- a/external-secrets-gsm/Chart.yaml
+++ b/external-secrets-gsm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: external-secrets-gsm
+description: A Helm chart for deploying any External Secrets where values live in Google Secrets Manager
+type: application
+version: 0.9.0
+appVersion: 0.9.0

--- a/external-secrets-gsm/templates/cert-secret.yaml
+++ b/external-secrets-gsm/templates/cert-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalCert.secretName }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.externalCert.secretName }} 
+    creationPolicy: Owner
+  data:
+  - secretKey: tls.crt
+    remoteRef:
+      key: {{ .Values.externalCert.certPrefix }}-crt
+  - secretKey: tls.key
+    remoteRef:
+      key: {{ .Values.externalCert.certPrefix }}-key
+

--- a/external-secrets-gsm/templates/ig-ob-signing-key-secret.yaml
+++ b/external-secrets-gsm/templates/ig-ob-signing-key-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.ig.ob.signingKey.secretName }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.ig.ob.signingKey.secretName }}
+    creationPolicy: Owner
+  data:
+  - secretKey: {{ .Values.ig.ob.signingKey.fileName }}
+    remoteRef:
+      key: {{ .Values.ig.ob.signingKey.googleSecretName }}

--- a/external-secrets-gsm/templates/ig-test-trusted-directory-secret.yaml
+++ b/external-secrets-gsm/templates/ig-test-trusted-directory-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.ig.testTrustedDirectory.secretName }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.ig.testTrustedDirectory.secretName }}
+    creationPolicy: Owner
+  data:
+  - secretKey: {{ .Values.ig.testTrustedDirectory.fileName }}
+    remoteRef:
+      key: {{ .Values.ig.testTrustedDirectory.googleSecretName }}

--- a/external-secrets-gsm/templates/ig-truststore-secret.yaml
+++ b/external-secrets-gsm/templates/ig-truststore-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.ig.truststore.secretName }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.ig.truststore.secretName }}
+    creationPolicy: Owner
+  data:
+  - secretKey: {{ .Values.ig.truststore.fileName }}
+    remoteRef:
+      key: {{ .Values.ig.truststore.googleSecretName }}

--- a/external-secrets-gsm/templates/ob-cert-secret.yaml
+++ b/external-secrets-gsm/templates/ob-cert-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.openBankingCert.secretName }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.openBankingCert.secretName }}
+    creationPolicy: Owner
+  data:
+  - secretKey: tls.crt
+    remoteRef:
+      key: {{ .Values.openBankingCert.certPrefix }}-crt
+  - secretKey: tls.key
+    remoteRef:
+      key: {{ .Values.openBankingCert.certPrefix }}-key

--- a/external-secrets-gsm/templates/rcs-signing-secret.yaml
+++ b/external-secrets-gsm/templates/rcs-signing-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.rcs.signing.secretName }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.rcs.signing.secretName }}
+    creationPolicy: Owner
+  data:
+  - secretKey: rcs-signing.pem
+    remoteRef:
+      key: {{ .Values.rcs.signing.certPrefix }}-crt
+  - secretKey: rcs-signing.key
+    remoteRef:
+      key: {{ .Values.rcs.signing.certPrefix }}-key

--- a/external-secrets-gsm/templates/secretstore.yaml
+++ b/external-secrets-gsm/templates/secretstore.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: gcp-store
+  annotations:
+    "helm.sh/hook": pre-install
+spec:
+  provider:
+    gcpsm:
+      projectID: {{ .Values.externalCert.projectId }}

--- a/external-secrets-gsm/templates/test-initialiser-secret.yaml
+++ b/external-secrets-gsm/templates/test-initialiser-secret.yaml
@@ -1,0 +1,20 @@
+{{- if eq .Values.environment.fr_platform.type "FIDC" }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store
+  target:
+    name: {{ .Values.name }}
+    creationPolicy: Owner
+  data:
+    - secretKey: cdm-admin-password
+      remoteRef:
+        key: {{ .Values.version }}-cdm-admin-password
+    - secretKey: cdm-admin-user
+      remoteRef:
+        key: {{ .Values.version }}-cdm-admin-user
+{{ end }}

--- a/mutating-webhook/Chart.yaml
+++ b/mutating-webhook/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ingress-mutator
+description: A Helm chart for modifying existing ingresses with whitelist and ssl certificates
+type: application
+version: 0.9.0
+appVersion: 0.9.0

--- a/mutating-webhook/templates/Certificate.yaml
+++ b/mutating-webhook/templates/Certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate  
+metadata:  
+  name: selfsigned-cert  
+spec:  
+  secretName: ingress-mutator-certs  
+  dnsNames:  
+    - ingress-mutator.{{ .Values.namespace }}.svc  
+    - ingress-mutator.{{ .Values.namespace }}.svc.cluster.local  
+  issuerRef:  
+    name: selfsigned-issuer

--- a/mutating-webhook/templates/Deployment.yaml
+++ b/mutating-webhook/templates/Deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-mutator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-mutator
+  template:
+    metadata:
+      labels:
+        app: ingress-mutator
+    spec:
+      volumes:
+      - name: ingress-mutator-certs
+        secret:
+          secretName: ingress-mutator-certs
+      containers:
+        - name: mutator
+          image: eu.gcr.io/sbat-gcr-develop/securebanking/mutators/ingress:latest
+          imagePullPolicy: Always
+          env:
+            - name: INGRESS_WHITELIST
+              value: "{{ .Values.whitelist }}"
+          volumeMounts:
+          - name: ingress-mutator-certs
+            mountPath: /app/ssl
+          resources: {}

--- a/mutating-webhook/templates/Issuer.yaml
+++ b/mutating-webhook/templates/Issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer  
+metadata:  
+  name: selfsigned-issuer  
+spec:  
+  selfSigned: {}  

--- a/mutating-webhook/templates/MutatingWebhookConfiguration.yaml
+++ b/mutating-webhook/templates/MutatingWebhookConfiguration.yaml
@@ -1,0 +1,30 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: ingress-mutator
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Values.selfSignedCert }}
+webhooks:
+  - name: ingress-mutator.default.svc
+    clientConfig:
+      caBundle: Cg==
+      service:
+        name: ingress-mutator
+        namespace: {{ .Values.namespace }}
+        path: "/mutate"
+        port: 443
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["networking.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["ingresses"]
+    sideEffects: None
+    timeoutSeconds: 5
+    failurePolicy: Ignore
+    namespaceSelector:
+      matchExpressions:
+        - key: "name"
+          operator: "NotIn"
+          values:
+            - cdk
+    admissionReviewVersions: ["v1"]

--- a/mutating-webhook/templates/Service.yaml
+++ b/mutating-webhook/templates/Service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-mutator
+spec:
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 8080
+  selector:
+    app: ingress-mutator


### PR DESCRIPTION
Add helper helm charts to repo and a way of creating a release to push to the artifact 

We don't have maven or other packages like we do in our other repos so can't use the release template we use in the parent repo. 

For now the github action is going to be called manually, but once confirmed working can do it so it runs when a tag is created

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/768