### PR TITLE
768 - Create and deploy new release deployment cluster

### DIFF
--- a/external-secrets-gsm/Chart.yaml
+++ b/external-secrets-gsm/Chart.yaml
@@ -4,3 +4,7 @@ description: A Helm chart for deploying any External Secrets where values live i
 type: application
 version: 0.9.0
 appVersion: 0.9.0
+dependencies:
+  - name: external-secrets
+    version: 0.7.2
+    repository: https://charts.external-secrets.io


### PR DESCRIPTION
Because we've moved the external-secrets-gsm helm chart to third party, it means that external-secrets has to already exist, so adding it as a dependency to the external-secrets-gsm package means it should get installed first

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/768