### PR TITLE
1452: Investigate relenvs v3 keystore issue

### DIFF
--- a/external-secrets-gsm/Chart.yaml
+++ b/external-secrets-gsm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: external-secrets-gsm
 description: A Helm chart for deploying any External Secrets where values live in Google Secrets Manager
 type: application
-version: 3.0.0
-appVersion: 3.0.0
+version: 3.0.1
+appVersion: 3.0.1

--- a/external-secrets-gsm/templates/ig-ob-signing-key-secret.yaml
+++ b/external-secrets-gsm/templates/ig-ob-signing-key-secret.yaml
@@ -12,7 +12,7 @@ spec:
     name: {{ .Values.ig.ob.signingKey.clusterSecretName }}
     creationPolicy: Owner
   data:
-  - secretKey: ig-core-signing-key.p12
+  - secretKey: ig-ob-signing-key.p12
     remoteRef:
       key: {{ .Values.ig.ob.signingKey.googleSecretName }}
 {{ end }}


### PR DESCRIPTION
Correct name for `ig-ob-signing-key` to be created as in cluster, name had been incorrectly changed to `ig-core-signing-key` where`IG` is expecting `ig-ob-signing-key` and rightfully complains the file does not exist

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1452