### PR TITLE
1682: Use new Helm files to deploy to Relenv

### DIFF
--- a/external-secrets-gsm/templates/ig-ob-signing-key-secret.yaml
+++ b/external-secrets-gsm/templates/ig-ob-signing-key-secret.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.environment.sapigType "ob" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -15,4 +14,3 @@ spec:
   - secretKey: ig-ob-signing-key.p12
     remoteRef:
       key: {{ .Values.ig.signingKey.externalSecretName }}
-{{ end }}

--- a/external-secrets-gsm/templates/ig-test-trusted-directory-secret.yaml
+++ b/external-secrets-gsm/templates/ig-test-trusted-directory-secret.yaml
@@ -11,6 +11,6 @@ spec:
     name: {{ .Values.ig.testTrustedDirectory.clusterSecretName }}
     creationPolicy: Owner
   data:
-  - secretKey: test-trusted-dir-keystore.p12
+  - secretKey: test-trusted-directory-keystore.p12
     remoteRef:
       key: {{ .Values.ig.testTrustedDirectory.externalSecretName }}


### PR DESCRIPTION
- Remove OB only for ig-ob-signing-key as required in Core
- Rename test trusted directory keystore

Issue: https://github.com/secureapigateway/secureapigateway/issues/1682